### PR TITLE
enable using variables in mutations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ export class Lokka {
     return this.send(queryWithFragments, vars);
   }
 
-  mutate(query) {
+  mutate(query, vars) {
     if (!query) {
       throw new Error('query is required!');
     }
@@ -85,7 +85,7 @@ export class Lokka {
     const fragments = this._findFragments(mutationQuery);
     const queryWithFragments = `${mutationQuery}\n${fragments.join('\n')}`;
 
-    return this.send(queryWithFragments);
+    return this.send(queryWithFragments, vars);
   }
 
   watchQuery(query, _vars, _callback) {


### PR DESCRIPTION
Right now Lokka's `mutate` method doesn't accept variables. This minimal pull request adds variables.
