### PR TITLE
Publish `lib` to the npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,4 @@
 .DS_Store
 .idea
 npm-debug.log
-lib
 .babelrc


### PR DESCRIPTION
It's really difficult to include this package in any other build system
for use in a browser. Publishing the lib directory at least allows for
other developers to choose how to build lokka in to their projects.
